### PR TITLE
Change to monthly dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,6 @@ updates:
 - package-ecosystem: cargo
   directory: "/"
   schedule:
-    interval: daily
+    interval: monthly
     time: "04:00"
   open-pull-requests-limit: 10


### PR DESCRIPTION
Security vulnerabilities should not be a big deal, and I'm not using this too much.